### PR TITLE
fix some bugs in the shell script

### DIFF
--- a/transcode-videos.sh
+++ b/transcode-videos.sh
@@ -440,7 +440,7 @@ process_360_recursive() {
     process_360 "$src" "$dest"
 
     for subdir in "$src"/*/; do
-        if [[ -d "$subdir" && "$(basename "$subdir")" != "Processed" ]]; then
+        if [[ -d "$subdir" && "$(realpath "$subdir")" != "$(realpath "$dest")" ]]; then
             local subdest="${dest}/${subdir#$src}"
             [[ ! -d "$subdest" ]] && mkdir -p "$subdest"
             process_360_recursive "$subdir" "$subdest"
@@ -704,7 +704,7 @@ transcode_mp4_recursive() {
     transcode_mp4 "$src" "$dest"
 
     for subdir in "$src"/*/; do
-        if [[ -d "$subdir" && "$(basename "$subdir")" != "Processed" ]]; then
+        if [[ -d "$subdir" && "$(realpath "$subdir")" != $(realpath "$dest") ]]; then
             local subdest="${dest}/${subdir#$src}"
             [[ ! -d "$subdest" ]] && mkdir -p "$subdest"
             transcode_mp4_recursive "$subdir" "$subdest"
@@ -781,7 +781,7 @@ copy_non_media_files_recursive() {
     copy_non_media_files "$src" "$dest"
 
     for subdir in "$src"/*/; do
-        if [[ -d "$subdir" && "$(basename "$subdir")" != "Processed" ]]; then
+        if [[ -d "$subdir" && "$(realpath "$subdir")" != $(realpath "$dest") ]]; then
             local subdest="${dest}/${subdir#$src}"
             [[ ! -d "$subdest" ]] && mkdir -p "$subdest"
             copy_non_media_files_recursive "$subdir" "$subdest"

--- a/transcode-videos.sh
+++ b/transcode-videos.sh
@@ -106,7 +106,7 @@ search_and_confirm_files() {
     echo ""
     echo "Searching for files in $input_folder..."
     shopt -s nullglob
-    files_found=($(find "$input_folder" -type f \( -name "*.mp4" -o -name "*.MP4" -o -name "*.ts" -o -name "*.TS" -o -name "*.mkv" -o -name "*.MKV" -o -name "*.avi" -o -name "*.AVI" -o -name "*.mov" -o -name "*.MOV" -o -name "*.flv" -o -name "*.FLV" -o -name "*.wmv" -o -name "*.WMV" -o -name "*.360" \)))
+    files_found=$(find "$input_folder" -type f \( -name "*.mp4" -o -name "*.MP4" -o -name "*.ts" -o -name "*.TS" -o -name "*.mkv" -o -name "*.MKV" -o -name "*.avi" -o -name "*.AVI" -o -name "*.mov" -o -name "*.MOV" -o -name "*.flv" -o -name "*.FLV" -o -name "*.wmv" -o -name "*.WMV" -o -name "*.360" \))
     
     if [ ${#files_found[@]} -eq 0 ]; then
         echo "No files found in the specified folder."


### PR DESCRIPTION
This pull request addresses two bugs I discovered in the shell script:
- Incorrectly splitting file names that contain spaces.
- Infinite recursion into subpaths when the destination is a subdirectory of the source directory.